### PR TITLE
Clarify ':ro' option in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
     container_name: grafana
     image: grafana/grafana-oss:9.4.3
     volumes:
+      # Note: The 'ro' option specifies that the volume is mounted in read-only mode.
+      # However, certain files such as grafana.ini may require write access. Be mindful of security implications when removing ':ro'.
       - ./grafana/etc:/etc/grafana:ro
       - grafana-lib:/var/lib/grafana
       - grafana-log:/var/log/grafana

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     volumes:
       # Note: The 'ro' option specifies that the volume is mounted in read-only mode.
       # However, certain files such as grafana.ini may require write access. Be mindful of security implications when removing ':ro'.
+      # Docs : https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3
       - ./grafana/etc:/etc/grafana:ro
       - grafana-lib:/var/lib/grafana
       - grafana-log:/var/log/grafana


### PR DESCRIPTION
Update Docker Compose comment to clarify use of ':ro' for file permissions.
`Fixes: #7` 